### PR TITLE
Fix dark mermaids in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ to show how parts of the system could be organized:
 
 #### Everything independent
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Relation Service]
@@ -290,7 +290,7 @@ B --> S
 
 #### Relations embedded in Film service
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph f [Film Service]
@@ -308,7 +308,7 @@ B --> S
 
 #### Relations embedded in Starship service
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph f [Film Service]
@@ -326,7 +326,7 @@ B --> S
 
 #### Relations embedded across services
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph f [Film Service]
@@ -346,7 +346,7 @@ B --> S
 
 #### Everything in one backend monolith
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 subgraph f [Monolithic Service]
     G{{Knit Gateway}}

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -23,7 +23,7 @@ component is its own sub-directory and has its own README that shows how
 to run that part of the system:
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]

--- a/tutorial/starwars-film-service-go/README.md
+++ b/tutorial/starwars-film-service-go/README.md
@@ -11,7 +11,7 @@ to see where the film service fits into the bigger
 picture.
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]

--- a/tutorial/starwars-knit-client-app-ts/README.md
+++ b/tutorial/starwars-knit-client-app-ts/README.md
@@ -6,7 +6,7 @@ In this tutorial the Knit Client app is implemented in TypeScript using [knit-ts
 [react.js] and [vite]. It calls the Knit Gateway to query for films with starships.
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]
@@ -212,7 +212,7 @@ client.do({
 ```
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 G --> F
 A[Knit Client] --> G[Knit Gateway]
@@ -250,7 +250,7 @@ client.do({
 ```
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 G --> F & S
 A[Knit Client] --> G[Knit Gateway]
@@ -293,7 +293,7 @@ client.do({
 ```
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 G --> F & R
 R --> S
@@ -344,7 +344,7 @@ client.do({
 ```
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 G --> R
 R --> F & S

--- a/tutorial/starwars-knit-gateway-go/README.md
+++ b/tutorial/starwars-knit-gateway-go/README.md
@@ -14,7 +14,7 @@ order, and flow required data from responses into subsequent requests until a
 query is fully executed.
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]

--- a/tutorial/starwars-knit-gateway-standalone/README.md
+++ b/tutorial/starwars-knit-gateway-standalone/README.md
@@ -15,7 +15,7 @@ order, and flow required data from responses into subsequent requests until a
 query is fully executed.
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]

--- a/tutorial/starwars-knit-relation-service-go/README.md
+++ b/tutorial/starwars-knit-relation-service-go/README.md
@@ -8,7 +8,7 @@ diagram below to see where the Knit relation service fits into the bigger
 picture. 
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]

--- a/tutorial/starwars-starship-service-go/README.md
+++ b/tutorial/starwars-starship-service-go/README.md
@@ -11,7 +11,7 @@ to see where the starship service fits into the bigger
 picture.
 
 ```mermaid
-%%{ init: { 'theme': 'base', 'flowchart': { 'curve': 'basis' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR
 A[Knit Client] --> B[Knit Gateway]
 subgraph r [Knit Relation Service]


### PR DESCRIPTION
I noticed that the mermaids are (visually) broken in dark mode.  Removing the theme [seems to fix it](https://github.com/bufbuild/knit-api#architecture), so I did that here.

| BEFORE | AFTER |
| - | - |
| ![Screenshot 2023-05-05 at 09 08 14](https://user-images.githubusercontent.com/15232461/236465891-b4b433e7-ef2f-469c-909b-d2c054ccd763.png) | ![Screenshot 2023-05-05 at 09 08 50](https://user-images.githubusercontent.com/15232461/236466032-90f8d48c-dc5c-4ab8-b0b0-e8e1593c236b.png) |

