### PR TITLE
Update readme to clarify gateway and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ The Knit gateway is available as a standalone binary, or it can be embedded
 in a Go service. The [Tutorial] shows how to use both types.
 
 ## Deployment
-Knit can be used with all existing gRPC, gRPC-web and connect protocol service
-without any modifications to those services. The Knit gateway is flexible and
-can be configured to points to any number of services, allowing Knit clients
-to call into them.
+Knit can be used with all gRPC, gRPC-web and Connect protocol services
+without any modifications. The Knit gateway 
+can be configured to point to any number of services, allowing Knit clients
+to call all of them.
 
 As the need arises more advanced usage of Knit can be employed, such as using
 relations, or splitting the system into finer grain RPCs (independent of the

--- a/README.md
+++ b/README.md
@@ -281,17 +281,14 @@ The Knit gateway is available as a standalone binary, or it can be embedded
 in a Go service. The [Tutorial] shows how to use both types.
 
 ## Deployment
-An important question in any system using Knit is where to put RPCs, both
-normal service RPCs and the RPCs that define relations.
+Knit can be used with all existing gRPC, gRPC-web and connect protocol service
+without any modifications to those services. The Knit gateway is flexible and
+can be configured to points to any number of services, allowing Knit clients
+to call into them.
 
-**The Knit gateway is flexible and can be configured to points at any number
-of services.**
-
-In particular, the decision of where to put RPCs defining relations will be
-based on which service "owns" the data mapping one type of entity to another.
-Using the Star Wars API in the [Tutorial], the question would be, do `Film`(s)
-know which `Starship`(s) appeared in them, or is it that `Starship`(s) know
-which `Film`(s) they were used in?
+As the need arises more advanced usage of Knit can be employed, such as using
+relations, or splitting the system into finer grain RPCs (independent of the
+services they are defined in).
 
 Below are several examples using the Star Wars API from the Knit [Tutorial]
 to show how parts of the system could be organized:
@@ -371,7 +368,7 @@ B --> F
 B --> S
 ```
 
-#### Everything in one backend monolith
+#### One backend monolith when using the Go embeddable gateway
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ declarative queries that shape the response, batching support to eliminate
 the N+1 problem, and first-class support for error handling with partial
 responses. It is built on top of Protobuf and Connect.**
 
-**Deply the Knit standalone gateway to call all your existing gRPC services from
-the web with the Knit client via normal HTTP load balancers. No changes to your
-services are needed to use the declarative queries, response shaping, or the
+**Deploy the Knit gateway to call all of your Connect/gRPC services from
+the web with the Knit client over HTTP/1.1 or HTTP/2. No changes to your
+services are needed to use type-safe declarative queries, response masking, or the
 error handling. Use more advanced feature like relations and partial responses
 as the need arises.**
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ declarative queries that shape the response, batching support to eliminate
 the N+1 problem, and first-class support for error handling with partial
 responses. It is built on top of Protobuf and Connect.**
 
+**Use the Knit standalone gateway to call all your existing gRPC services from
+the web with the Knit client via normal HTTP load balancers. No changes to your
+services are needed to use the declarative queries, response shaping, or the
+error handling. Use more advanced feature like relations and partial responses
+as the need arises.**
+
 **Knit is currently in alpha (α), and looking for feedback. Learn how to use it with the [Tutorial].**
 
 ---
@@ -18,6 +24,27 @@ Map of Knit repositories:
 - **[github.com/bufbuild/knit-demo]**: Source for the demo app at https://knit-demo.connect.build/
 
 ## Overview
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
+flowchart LR
+
+subgraph b [Browser]
+  C[Knit Client]
+end
+
+subgraph i [Cloud]
+  G[Knit Gateway]
+  X[Service X]
+  Y[Service Y]
+  Z[Service Z]
+end
+
+C -- http --> G
+G -- gRPC --> X
+G -- gRPC-web --> Y
+G -- connect --> Z
+```
+## Client queries
 Knit clients specify declarative queries that pull data from multiple backend APIs
 in a single call via the Knit gateway. Knit queries can shape the data into a
 hierarchy that matches the needs of the caller, and can filter the response to get

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ declarative queries that shape the response, batching support to eliminate
 the N+1 problem, and first-class support for error handling with partial
 responses. It is built on top of Protobuf and Connect.**
 
-**Use the Knit standalone gateway to call all your existing gRPC services from
+**Deply the Knit standalone gateway to call all your existing gRPC services from
 the web with the Knit client via normal HTTP load balancers. No changes to your
 services are needed to use the declarative queries, response shaping, or the
 error handling. Use more advanced feature like relations and partial responses


### PR DESCRIPTION
Update the root README to make it more obvious that Knit does not require any changes to existing service to get immediate benefit. Also update the overview to be a diagram of a deployment.