### PR TITLE
Fix 4 issues flagged across 4 files

### DIFF
--- a/tutorial/starwars-film-service-go/go.mod
+++ b/tutorial/starwars-film-service-go/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/bufbuild/connect-go v1.0.0
 	github.com/bufbuild/connect-grpcreflect-go v1.0.0
 	github.com/bufbuild/knit/tutorial/starwars-data-go v0.0.0-20230505135109-8bf7f257e49d
-	golang.org/x/net v0.55.0
+	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.33.0
 )
 
-require golang.org/x/text v0.37.0 // indirect
+require golang.org/x/text v0.39.0 // indirect

--- a/tutorial/starwars-knit-gateway-go/go.mod
+++ b/tutorial/starwars-knit-gateway-go/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/bufbuild/connect-go v1.7.0
 	github.com/bufbuild/connect-grpcreflect-go v1.0.1-0.20230317120624-8e24e9604364
 	github.com/bufbuild/knit-go v0.0.1
-	golang.org/x/net v0.55.0
+	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.33.0
 )
 
 require (
 	buf.build/gen/go/bufbuild/knit/bufbuild/connect-go v1.7.0-20230504140941-3dc602456973.1 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 )

--- a/tutorial/starwars-knit-relation-service-go/go.mod
+++ b/tutorial/starwars-knit-relation-service-go/go.mod
@@ -3,11 +3,11 @@ module github.com/bufbuild/knit/tutorial/starwars-knit-relation-service-go
 go 1.25.0
 
 require (
-	buf.build/gen/go/bufbuild/knit/protocolbuffers/go v1.30.0-20230504140941-3dc602456973.1
-	github.com/bufbuild/connect-go v1.7.0
-	github.com/bufbuild/connect-grpcreflect-go v1.0.1-0.20230317120624-8e24e9604364
-	golang.org/x/net v0.55.0
-	google.golang.org/protobuf v1.33.0
+    buf.build/gen/go/bufbuild/knit/protocolbuffers/go v1.30.0-20230504140941-3dc602456973.1
+    github.com/bufbuild/connect-go v1.7.0
+    github.com/bufbuild/connect-grpcreflect-go v1.0.1-0.20230317120624-8e24e9604364
+    golang.org/x/net v0.56.0
+    google.golang.org/protobuf v1.33.0
 )
 
-require golang.org/x/text v0.37.0 // indirect
+require golang.org/x/text v0.39.0 // indirect

--- a/tutorial/starwars-starship-service-go/go.mod
+++ b/tutorial/starwars-starship-service-go/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/bufbuild/connect-go v1.6.0
 	github.com/bufbuild/connect-grpcreflect-go v1.0.0
 	github.com/bufbuild/knit/tutorial/starwars-data-go v0.0.0-00010101000000-000000000000
-	golang.org/x/net v0.55.0
+	golang.org/x/net v0.56.0
 	google.golang.org/protobuf v1.33.0
 )
 
 replace github.com/bufbuild/knit/tutorial/starwars-data-go => ../starwars-data-go
 
-require golang.org/x/text v0.37.0 // indirect
+require golang.org/x/text v0.39.0 // indirect


### PR DESCRIPTION
A scan flagged a few things in this repository. This changes 4 files — one item each, described below.

**1. `tutorial/starwars-knit-relation-service-go/go.mod`, around line 1**

CVE-2026-46600 is a high-severity denial-of-service vulnerability in golang.org/x/net v0.55.0 caused by insufficient bounds checking during the parsing of SVCB or HTTPS DNS resource records. Attackers can send crafted DNS responses with oversized parameter values that overflow internal buffers, triggering a fatal runtime panic. If your application processes or forwards untrusted DNS traffic, this poses a direct availability risk requiring immediate remediation.

Update golang.org/x/net and golang.org/x/text to patched versions to resolve reported CVEs.

For reference: rule `CVE-2026-46600`. Rated high.

**2. `tutorial/starwars-film-service-go/go.mod`, around line 1**

The golang.org/x/net package contains a memory safety vulnerability where parsing malformed DNS SVCB or HTTPS records triggers an integer overflow, leading to a fatal runtime panic. This poses a High-risk Denial of Service (DoS) threat, as an attacker sending crafted or spoofed DNS responses can crash the application. Immediate remediation is required by upgrading the dependency to the patched version.

Upgrade vulnerable dependencies to patched versions, resolving the reported CVEs.

For reference: rule `CVE-2026-46600`. Rated high.

**3. `tutorial/starwars-starship-service-go/go.mod`, around line 1**

CVE-2026-46600 is a HIGH severity vulnerability in golang.org/x/net that triggers a runtime panic when parsing malformed SVCB or HTTPS DNS records. An attacker can exploit this by sending crafted DNS responses containing oversized parameter values, causing a buffer overflow during message parsing. This results in a remote Denial of Service (DoS) that can crash network-facing Go applications. Immediate patching is required to mitigate the risk.

Update vulnerable dependencies to their fixed versions to resolve reported CVEs.

For reference: rule `CVE-2026-46600`. Rated high.

**4. `tutorial/starwars-knit-gateway-go/go.mod`, around line 1**

This vulnerability allows an attacker to trigger a runtime panic in the DNS parser by supplying malformed SVCB or HTTPS resource records with oversized parameter values. The resulting crash causes a Denial of Service (DoS), severely impacting application availability. Rated HIGH severity due to the critical exposure of network-facing gateways handling untrusted DNS responses. Immediate dependency upgrade is required to mitigate the risk.

Updates the two vulnerable dependencies to their patched versions, fixing the reported CVEs.

For reference: rule `CVE-2026-46600`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
